### PR TITLE
Fix comments for ToDef and ToInt

### DIFF
--- a/to.go
+++ b/to.go
@@ -11,7 +11,6 @@ func To[T any](v *T) T {
 	return *v
 }
 
-// ToInt returns the value of the int pointer passed in or int if the pointer is nil.
 // ToInt returns the value of the int pointer passed in or 0 if the pointer is nil.
 func ToInt(v *int) int {
 	if v == nil {

--- a/todef.go
+++ b/todef.go
@@ -2,7 +2,7 @@ package ptr
 
 import "time"
 
-// ToDef returns the value of the int pointer passed in or default value if the pointer is nil.
+// ToDef returns the value of the pointer passed in or default value if the pointer is nil.
 func ToDef[T any](v *T, def T) T {
 	if v == nil {
 		return def


### PR DESCRIPTION
This PR corrects comments for `ToDef` and `ToInt` functions.